### PR TITLE
更新PHP镜像版本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+*.swp

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,0 +1,2 @@
+*.conf
+!default.conf

--- a/conf/rule.d/.gitignore
+++ b/conf/rule.d/.gitignore
@@ -1,0 +1,2 @@
+*.rule
+!default.rule

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm-alpine
+FROM php:7.3-fpm-alpine
 
 WORKDIR /usr/local/etc
 

--- a/wwwroot/.gitignore
+++ b/wwwroot/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!default


### PR DESCRIPTION
降低版本为7.3，使用7.4+版本会抛出一个Notice，无法进行pecl安装扩展行为